### PR TITLE
Logger deprecation of warn

### DIFF
--- a/spectral_connectivity/minimum_phase_decomposition.py
+++ b/spectral_connectivity/minimum_phase_decomposition.py
@@ -31,7 +31,7 @@ def _get_intial_conditions(cross_spectral_matrix):
             ifft(cross_spectral_matrix, axis=-3)[..., 0:1, :, :].real
         ).swapaxes(-1, -2)
     except np.linalg.linalg.LinAlgError:
-        logger.warn(
+        logger.warning(
             'Computing the initial conditions using the Cholesky failed. '
             'Using a random initial condition.')
 


### PR DESCRIPTION
Currently, `logger` throws `DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead`