### PR TITLE
Update connectivity.py to fix documentation of coherence_magnitude()

### DIFF
--- a/spectral_connectivity/connectivity.py
+++ b/spectral_connectivity/connectivity.py
@@ -325,9 +325,15 @@ class Connectivity:
 
     @_asnumpy
     def coherence_magnitude(self):
-        """The magnitude of the complex coherency.
+        """The magnitude squared of the complex coherency. Note that the 
+        squared modulus of coherency (originally a complex quantity) is the 
+        magnitude-squared coherence (i.e., the normalized, real component of coherency). 
+        This value should bounded by 0 and 1.
 
-        Note that this is not the magnitude squared coherence.
+        Hansson-Sandsten M (2011) Cross-spectrum and coherence function 
+        estimation using time-delayed Thomson multitapers. In: 2011 IEEE 
+        International Conference on Acoustics, Speech and Signal 
+        Processing (ICASSP), pp 4240–4243.
 
         Returns
         -------


### PR DESCRIPTION
Fix typo in coherence_magnitude() in connectivity.py. Originally, the file said that the modulus squared of coherency was not the magnitude squared coherence. However, I believe that's the definition (i.e., drop the complex component and normalize the real component to be bounded by 0 and 1). Provided citation as well for clarity, so folks can see the simplified equation.