### PR TITLE
feat(fft): switch to scipy.fft; mirror CPU/GPU imports

### DIFF
--- a/spectral_connectivity/transforms.py
+++ b/spectral_connectivity/transforms.py
@@ -21,12 +21,12 @@ if os.environ.get("SPECTRAL_CONNECTIVITY_ENABLE_GPU") == "true":
             "spectral_connectivity."
         )
         import numpy as xp
-        from scipy.fftpack import fft, fftfreq, ifft, next_fast_len
+        from scipy.fft import fft, fftfreq, ifft, next_fast_len
         from scipy.linalg import lstsq
 else:
     logger.info("Using CPU for spectral_connectivity...")
     import numpy as xp
-    from scipy.fftpack import fft, fftfreq, ifft, next_fast_len
+    from scipy.fft import fft, fftfreq, ifft, next_fast_len
     from scipy.linalg import lstsq
 
 

--- a/tests/test_minimum_phase_decomposition.py
+++ b/tests/test_minimum_phase_decomposition.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.fftpack import fft, ifft
+from scipy.fft import fft, ifft
 from scipy.signal import freqz_zpk
 
 from spectral_connectivity.minimum_phase_decomposition import (


### PR DESCRIPTION
## Summary
- Replace deprecated `scipy.fftpack` with modern `scipy.fft` imports
- CPU/GPU import symmetry maintained (`scipy.fft` vs `cupyx.scipy.fft`)
- Tests pass with no new failures

## Test plan
- [x] Replaced `scipy.fftpack` with `scipy.fft` in transforms.py and tests
- [x] CPU/GPU import symmetry maintained  
- [x] Tests pass locally (same 3 pre-existing failures, no new ones)

🤖 Generated with [Claude Code](https://claude.ai/code)