### PR TITLE
docs: fix typos and clarify docstrings (no functional change)

### DIFF
--- a/spectral_connectivity/connectivity.py
+++ b/spectral_connectivity/connectivity.py
@@ -129,7 +129,7 @@ class Connectivity:
     References
     ----------
     .. [1] Dhamala, M., Rangarajan, G., and Ding, M. (2008). Analyzing
-           information flow in brain networks with noxparametric Granger
+           information flow in brain networks with nonparametric Granger
            causality. NeuroImage 41, 354-362.
 
     """
@@ -1130,7 +1130,7 @@ def _estimate_noise_covariance(minimum_phase):
     References
     ----------
     .. [1] Dhamala, M., Rangarajan, G., and Ding, M. (2008). Analyzing
-           information flow in brain networks with noxparametric Granger
+           information flow in brain networks with nonparametric Granger
            causality. NeuroImage 41, 354-362.
 
     """
@@ -1159,7 +1159,7 @@ def _estimate_transfer_function(minimum_phase):
     References
     ----------
     .. [1] Dhamala, M., Rangarajan, G., and Ding, M. (2008). Analyzing
-           information flow in brain networks with noxparametric Granger
+           information flow in brain networks with nonparametric Granger
            causality. NeuroImage 41, 354-362.
 
     """
@@ -1211,7 +1211,7 @@ def _remove_instantaneous_causality(noise_covariance):
 
 
 def _set_diagonal_to_zero(x):
-    """Sets the diaginal of the last two dimensions to zero."""
+    """Sets the diagonal of the last two dimensions to zero."""
     n_signals = x.shape[-1]
     diagonal_index = xp.diag_indices(n_signals)
     x[..., diagonal_index[0], diagonal_index[1]] = 0

--- a/spectral_connectivity/minimum_phase_decomposition.py
+++ b/spectral_connectivity/minimum_phase_decomposition.py
@@ -26,7 +26,7 @@ def _conjugate_transpose(x):
     return x.swapaxes(-1, -2).conjugate()
 
 
-def _get_intial_conditions(cross_spectral_matrix):
+def _get_initial_conditions(cross_spectral_matrix):
     """Returns a guess for the minimum phase factor using the Cholesky
     factorization.
 
@@ -188,7 +188,7 @@ def minimum_phase_decomposition(
     I = xp.eye(n_signals)
     is_converged = xp.zeros(n_time_points, dtype=bool)
     minimum_phase_factor = xp.zeros(cross_spectral_matrix.shape)
-    minimum_phase_factor[..., :, :, :] = _get_intial_conditions(cross_spectral_matrix)
+    minimum_phase_factor[..., :, :, :] = _get_initial_conditions(cross_spectral_matrix)
 
     for iteration in range(max_iterations):
         logger.debug(

--- a/tests/test_minimum_phase_decomposition.py
+++ b/tests/test_minimum_phase_decomposition.py
@@ -6,7 +6,7 @@ from spectral_connectivity.minimum_phase_decomposition import (
     _check_convergence,
     _conjugate_transpose,
     _get_causal_signal,
-    _get_intial_conditions,
+    _get_initial_conditions,
     minimum_phase_decomposition,
 )
 
@@ -48,7 +48,7 @@ def test__get_initial_conditions():
         * 4
     )
     cross_spectral_matrix[..., 1, 0] = 0
-    minimum_phase_factor = _get_intial_conditions(cross_spectral_matrix)
+    minimum_phase_factor = _get_initial_conditions(cross_spectral_matrix)
     expected_cross_spectral_matrix = np.zeros(
         (n_time_samples, 1, n_signals, n_signals), dtype=complex
     )


### PR DESCRIPTION
## Summary
- Fix misleading typos in documentation and docstrings
- Improve clarity without changing any runtime behavior
- Clean up function naming consistency

## Changes
- **connectivity.py:** "noxparametric" → "nonparametric" in 3 locations
- **connectivity.py:** "diaginal" → "diagonal" in `_set_diagonal_to_zero` docstring  
- **minimum_phase_decomposition.py:** "_get_intial_conditions" → "_get_initial_conditions"
- **tests:** Update function name imports accordingly

## Verification
- [x] Zero functional changes - all tests maintain exact same status
- [x] Documentation now correctly spells common technical terms
- [x] Function names are internally consistent

🤖 Generated with [Claude Code](https://claude.ai/code)