### PR TITLE
feat(api): validate expectation_type with clear error

### DIFF
--- a/examples/Intro_tutorial.ipynb
+++ b/examples/Intro_tutorial.ipynb
@@ -48,7 +48,7 @@
     "phase_offset = np.pi / 2\n",
     "signal[:, 1] = np.sin((2 * np.pi * time * frequency_of_interest) + phase_offset)\n",
     "\n",
-    "noise = np.random.normal(0, 4, signal.shape)\n"
+    "noise = np.random.normal(0, 4, signal.shape)"
    ]
   },
   {
@@ -105,7 +105,7 @@
     "axes[1].set_xlabel(\"Time\")\n",
     "axes[1].set_ylabel(\"Amplitude\")\n",
     "axes[1].set_xlim((0.95, 1.05))\n",
-    "axes[1].set_ylim((-10, 10))\n"
+    "axes[1].set_ylim((-10, 10))"
    ]
   },
   {
@@ -225,7 +225,7 @@
    "source": [
     "from spectral_connectivity import Multitaper\n",
     "\n",
-    "Multitaper?"
+    "?Multitaper"
    ]
   },
   {
@@ -256,7 +256,7 @@
     }
    ],
    "source": [
-    "signal.shape\n"
+    "signal.shape"
    ]
   },
   {
@@ -292,7 +292,7 @@
     }
    ],
    "source": [
-    "sampling_frequency\n"
+    "sampling_frequency"
    ]
   },
   {
@@ -339,7 +339,7 @@
     "multitaper = Multitaper(\n",
     "    signal + noise, sampling_frequency=sampling_frequency, time_halfbandwidth_product=5\n",
     ")\n",
-    "multitaper\n"
+    "multitaper"
    ]
   },
   {
@@ -366,7 +366,7 @@
     }
    ],
    "source": [
-    "multitaper.time_window_duration\n"
+    "multitaper.time_window_duration"
    ]
   },
   {
@@ -386,7 +386,7 @@
     }
    ],
    "source": [
-    "multitaper.time_window_step\n"
+    "multitaper.time_window_step"
    ]
   },
   {
@@ -415,7 +415,7 @@
     }
    ],
    "source": [
-    "multitaper.frequency_resolution\n"
+    "multitaper.frequency_resolution"
    ]
   },
   {
@@ -442,7 +442,7 @@
     }
    ],
    "source": [
-    "multitaper.nyquist_frequency\n"
+    "multitaper.nyquist_frequency"
    ]
   },
   {
@@ -472,7 +472,7 @@
    ],
    "source": [
     "fourier_coefficients = multitaper.fft()\n",
-    "fourier_coefficients.shape\n"
+    "fourier_coefficients.shape"
    ]
   },
   {
@@ -499,7 +499,7 @@
     }
    ],
    "source": [
-    "multitaper.time\n"
+    "multitaper.time"
    ]
   },
   {
@@ -520,7 +520,7 @@
     }
    ],
    "source": [
-    "multitaper.frequencies\n"
+    "multitaper.frequencies"
    ]
   },
   {
@@ -626,7 +626,7 @@
    "source": [
     "from spectral_connectivity import Connectivity\n",
     "\n",
-    "Connectivity?"
+    "?Connectivity"
    ]
   },
   {
@@ -679,7 +679,7 @@
     "    frequencies=multitaper.frequencies,\n",
     "    time=multitaper.time,\n",
     "    blocks=1,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -695,7 +695,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "connectivity = Connectivity.from_multitaper(multitaper)\n"
+    "connectivity = Connectivity.from_multitaper(multitaper)"
    ]
   },
   {
@@ -723,7 +723,7 @@
    ],
    "source": [
     "power = connectivity.power()\n",
-    "power.shape\n"
+    "power.shape"
    ]
   },
   {
@@ -750,7 +750,7 @@
     }
    ],
    "source": [
-    "connectivity.frequencies.shape\n"
+    "connectivity.frequencies.shape"
    ]
   },
   {
@@ -780,7 +780,7 @@
     "connectivity = Connectivity.from_multitaper(\n",
     "    multitaper, expectation_type=\"time_trials_tapers\", blocks=1\n",
     ")\n",
-    "connectivity.power().shape\n"
+    "connectivity.power().shape"
    ]
   },
   {
@@ -821,7 +821,7 @@
    "source": [
     "plt.plot(connectivity.frequencies, connectivity.power())\n",
     "plt.ylabel(\"Power\")\n",
-    "plt.xlabel(\"Frequency\")\n"
+    "plt.xlabel(\"Frequency\")"
    ]
   },
   {
@@ -849,7 +849,7 @@
    ],
    "source": [
     "coherence = connectivity.coherence_magnitude()\n",
-    "coherence.shape\n"
+    "coherence.shape"
    ]
   },
   {
@@ -888,7 +888,7 @@
     }
    ],
    "source": [
-    "plt.plot(connectivity.frequencies, coherence[:, 0, 1])\n"
+    "plt.plot(connectivity.frequencies, coherence[:, 0, 1])"
    ]
   },
   {
@@ -928,7 +928,7 @@
     ")\n",
     "\n",
     "coherence = connectivity.coherence_magnitude()\n",
-    "coherence.shape\n"
+    "coherence.shape"
    ]
   },
   {
@@ -955,7 +955,7 @@
     }
    ],
    "source": [
-    "multitaper.frequency_resolution\n"
+    "multitaper.frequency_resolution"
    ]
   },
   {
@@ -1011,7 +1011,7 @@
     "plt.xlim(time_extent)\n",
     "plt.xlabel(\"Time\")\n",
     "plt.ylabel(\"Frequency\")\n",
-    "plt.colorbar()\n"
+    "plt.colorbar()"
    ]
   },
   {
@@ -1570,7 +1570,7 @@
     "    method=\"coherence_magnitude\",\n",
     ")\n",
     "\n",
-    "coherence\n"
+    "coherence"
    ]
   },
   {
@@ -2113,7 +2113,7 @@
     }
    ],
    "source": [
-    "coherence.sel(frequency=slice(100, 300))\n"
+    "coherence.sel(frequency=slice(100, 300))"
    ]
   },
   {
@@ -2154,7 +2154,7 @@
    "source": [
     "coherence.sel(frequency=slice(100, 300)).plot(\n",
     "    x=\"time\", y=\"frequency\", row=\"source\", col=\"target\"\n",
-    ")\n"
+    ")"
    ]
   },
   {

--- a/examples/Tutorial_On_Simulated_Examples.ipynb
+++ b/examples/Tutorial_On_Simulated_Examples.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "from spectral_connectivity import Multitaper\n",
     "from spectral_connectivity import Connectivity\n",
-    "from spectral_connectivity import multitaper_connectivity\n"
+    "from spectral_connectivity import multitaper_connectivity"
    ]
   },
   {
@@ -86,7 +86,7 @@
     "connectivity = Connectivity.from_multitaper(multitaper)\n",
     "\n",
     "axes[1].plot(connectivity.frequencies, connectivity.power().squeeze())\n",
-    "axes[1].set_title(\"Frequency Domain\")\n"
+    "axes[1].set_title(\"Frequency Domain\")"
    ]
   },
   {
@@ -152,7 +152,7 @@
     "\n",
     "axes[1].plot(connectivity.frequencies, connectivity.power().squeeze())\n",
     "axes[1].set_title(\"Frequency Domain\")\n",
-    "axes[1].set_xlim((0, 100))\n"
+    "axes[1].set_xlim((0, 100))"
    ]
   },
   {
@@ -289,7 +289,7 @@
     "    pad=0.1,\n",
     "    label=\"Power\",\n",
     ")\n",
-    "cb.outline.set_linewidth(0)\n"
+    "cb.outline.set_linewidth(0)"
    ]
   },
   {
@@ -425,7 +425,7 @@
     "    label=\"Power\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -561,7 +561,7 @@
     "    label=\"Power\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -661,7 +661,7 @@
     ")\n",
     "connectivity = Connectivity.from_multitaper(multitaper)\n",
     "plt.subplot(2, 2, 4)\n",
-    "plt.plot(connectivity.frequencies, connectivity.coherence_magnitude()[0, :, 0, 1])\n"
+    "plt.plot(connectivity.frequencies, connectivity.coherence_magnitude()[0, :, 0, 1])"
    ]
   },
   {
@@ -754,7 +754,7 @@
     ")\n",
     "connectivity = Connectivity.from_multitaper(multitaper)\n",
     "plt.subplot(2, 2, 4)\n",
-    "plt.plot(connectivity.frequencies, connectivity.coherence_magnitude()[0, :, 0, 1])\n"
+    "plt.plot(connectivity.frequencies, connectivity.coherence_magnitude()[0, :, 0, 1])"
    ]
   },
   {
@@ -911,7 +911,7 @@
     "    label=\"Coherence\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -1068,7 +1068,7 @@
     "    label=\"Imaginary Coherence\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -1225,7 +1225,7 @@
     "    label=\"Phase Locking Value\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -1382,7 +1382,7 @@
     "    label=\"Phase Lag Index\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -1545,7 +1545,7 @@
     "    label=\"Weighted Phase Lag Index\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -1701,7 +1701,7 @@
     "    label=\"Debiased Squared Phase Lag Index\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -1864,7 +1864,7 @@
     "    label=\"Debiased Weighted Squared Phase Lag Index\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -2027,7 +2027,7 @@
     "    label=\"Pairwise Phase Consistency\",\n",
     ")\n",
     "cb.outline.set_linewidth(0)\n",
-    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))\n"
+    "print(\"frequency resolution: {}\".format(multitaper.frequency_resolution))"
    ]
   },
   {
@@ -2180,7 +2180,7 @@
     "axis_handles[4, 1].set_xlim((0.5, 2.5))\n",
     "axis_handles[4, 1].axhline(0, color=\"black\")\n",
     "axis_handles[4, 1].set_xticks([1])\n",
-    "axis_handles[4, 1].set_xticklabels([\"x1 → x2\"])\n"
+    "axis_handles[4, 1].set_xticklabels([\"x1 → x2\"])"
    ]
   },
   {
@@ -2328,7 +2328,7 @@
     "axis_handles[4, 1].set_xlim((0.5, 2.5))\n",
     "axis_handles[4, 1].axhline(0, color=\"black\")\n",
     "axis_handles[4, 1].set_xticks([1])\n",
-    "axis_handles[4, 1].set_xticklabels([\"x1 → x2\"])\n"
+    "axis_handles[4, 1].set_xticklabels([\"x1 → x2\"])"
    ]
   },
   {
@@ -2443,7 +2443,7 @@
     "axis_handles[1, 1].plot(\n",
     "    connectivity.time + multitaper.time_window_duration / 2, delay[..., 0, 1]\n",
     ")\n",
-    "axis_handles[1, 1].set_xlim(time_extent)\n"
+    "axis_handles[1, 1].set_xlim(time_extent)"
    ]
   },
   {
@@ -2588,7 +2588,7 @@
     "    [1, 2], [psi[..., 0, 1].squeeze(), psi[..., 1, 0].squeeze()], color=[\"b\", \"g\"]\n",
     ")\n",
     "axis_handles[4, 1].set_xlim((0.5, 2.5))\n",
-    "axis_handles[4, 1].axhline(0, color=\"black\")\n"
+    "axis_handles[4, 1].axhline(0, color=\"black\")"
    ]
   },
   {
@@ -2731,7 +2731,7 @@
     "    [1, 2], [psi[..., 0, 1].squeeze(), psi[..., 1, 0].squeeze()], color=[\"b\", \"g\"]\n",
     ")\n",
     "axis_handles[4, 1].set_xlim((0.5, 2.5))\n",
-    "axis_handles[4, 1].axhline(0, color=\"black\")\n"
+    "axis_handles[4, 1].axhline(0, color=\"black\")"
    ]
   },
   {
@@ -2851,7 +2851,7 @@
     ")\n",
     "axis_handles[1, 1].set_xlim(time_extent)\n",
     "axis_handles[1, 1].set_xlabel(\"Time [s]\")\n",
-    "axis_handles[1, 1].set_ylabel(\"Phase Slope Index\")\n"
+    "axis_handles[1, 1].set_ylabel(\"Phase Slope Index\")"
    ]
   },
   {
@@ -3004,7 +3004,7 @@
     "    pad=0.1,\n",
     "    label=\"Coherence\",\n",
     ")\n",
-    "cb.outline.set_linewidth(0)\n"
+    "cb.outline.set_linewidth(0)"
    ]
   },
   {
@@ -3157,7 +3157,7 @@
     "    pad=0.1,\n",
     "    label=\"Coherence\",\n",
     ")\n",
-    "cb.outline.set_linewidth(0)\n"
+    "cb.outline.set_linewidth(0)"
    ]
   },
   {
@@ -3251,7 +3251,7 @@
     ")\n",
     "plt.title(\"Global Coherence (1st component)\")\n",
     "plt.xlabel(\"Time [s]\")\n",
-    "plt.ylabel(\"Frequency [Hz]\")\n"
+    "plt.ylabel(\"Frequency [Hz]\")"
    ]
   },
   {
@@ -3826,7 +3826,7 @@
     "    method=\"coherence_magnitude\",\n",
     ")\n",
     "\n",
-    "coherence_magnitude\n"
+    "coherence_magnitude"
    ]
   },
   {
@@ -3858,7 +3858,7 @@
     }
    ],
    "source": [
-    "coherence_magnitude.plot(col=\"source\", row=\"target\", x=\"time\")\n"
+    "coherence_magnitude.plot(col=\"source\", row=\"target\", x=\"time\")"
    ]
   },
   {

--- a/examples/Tutorial_Using_Paper_Examples.ipynb
+++ b/examples/Tutorial_Using_Paper_Examples.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "    fig, axes = plt.subplots(1, 1, figsize=(3, 3), sharex=True, sharey=True)\n",
     "    axes.plot(c.frequencies, c.power().squeeze())\n",
-    "    plt.title(\"Power\")\n"
+    "    plt.title(\"Power\")"
    ]
   },
   {
@@ -148,7 +148,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*baccala_example2(), time_halfbandwidth_product=1)\n"
+    "plot_directional(*baccala_example2(), time_halfbandwidth_product=1)"
    ]
   },
   {
@@ -236,7 +236,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*baccala_example3(), time_halfbandwidth_product=3)\n"
+    "plot_directional(*baccala_example3(), time_halfbandwidth_product=3)"
    ]
   },
   {
@@ -321,7 +321,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*baccala_example4(), time_halfbandwidth_product=1)\n"
+    "plot_directional(*baccala_example4(), time_halfbandwidth_product=1)"
    ]
   },
   {
@@ -407,7 +407,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*baccala_example5(), time_halfbandwidth_product=1)\n"
+    "plot_directional(*baccala_example5(), time_halfbandwidth_product=1)"
    ]
   },
   {
@@ -493,7 +493,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*baccala_example6(), time_halfbandwidth_product=1)\n"
+    "plot_directional(*baccala_example6(), time_halfbandwidth_product=1)"
    ]
   },
   {
@@ -574,7 +574,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*ding_example1(), time_halfbandwidth_product=3)\n"
+    "plot_directional(*ding_example1(), time_halfbandwidth_product=3)"
    ]
   },
   {
@@ -660,7 +660,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*ding_example2a())\n"
+    "plot_directional(*ding_example2a())"
    ]
   },
   {
@@ -746,7 +746,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*ding_example2b(), time_halfbandwidth_product=2)\n"
+    "plot_directional(*ding_example2b(), time_halfbandwidth_product=2)"
    ]
   },
   {
@@ -839,7 +839,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*ding_example3(), time_halfbandwidth_product=1)\n"
+    "plot_directional(*ding_example3(), time_halfbandwidth_product=1)"
    ]
   },
   {
@@ -910,7 +910,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*Nedungadi_example1(), time_halfbandwidth_product=3)\n"
+    "plot_directional(*Nedungadi_example1(), time_halfbandwidth_product=3)"
    ]
   },
   {
@@ -981,7 +981,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*Nedungadi_example2(), time_halfbandwidth_product=3)\n"
+    "plot_directional(*Nedungadi_example2(), time_halfbandwidth_product=3)"
    ]
   },
   {
@@ -1065,7 +1065,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*Wen_example1(), time_halfbandwidth_product=1)\n"
+    "plot_directional(*Wen_example1(), time_halfbandwidth_product=1)"
    ]
   },
   {
@@ -1154,7 +1154,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*Wen_example2(), time_halfbandwidth_product=3)\n"
+    "plot_directional(*Wen_example2(), time_halfbandwidth_product=3)"
    ]
   },
   {
@@ -1231,7 +1231,7 @@
     "    )\n",
     "\n",
     "\n",
-    "plot_directional(*Dhamala_example1(), time_halfbandwidth_product=1)\n"
+    "plot_directional(*Dhamala_example1(), time_halfbandwidth_product=1)"
    ]
   },
   {
@@ -1349,7 +1349,7 @@
     ")\n",
     "ax[1].set_title(\"x2 -> x1\")\n",
     "ax[1].set_xlabel(\"Time\")\n",
-    "ax[1].set_ylabel(\"Frequency\")\n"
+    "ax[1].set_ylabel(\"Frequency\")"
    ]
   },
   {
@@ -1395,7 +1395,7 @@
     ")\n",
     "ax[1].set_title(\"x2 -> x1\")\n",
     "ax[1].set_xlabel(\"Time\")\n",
-    "ax[1].set_ylabel(\"Frequency\")\n"
+    "ax[1].set_ylabel(\"Frequency\")"
    ]
   },
   {
@@ -1437,7 +1437,7 @@
     "ax[1].pcolormesh(c.time, c.frequencies, pdc[..., :, 1, 0].T, cmap=\"viridis\")\n",
     "ax[1].set_title(\"x2 -> x1\")\n",
     "ax[1].set_xlabel(\"Time\")\n",
-    "ax[1].set_ylabel(\"Frequency\")\n"
+    "ax[1].set_ylabel(\"Frequency\")"
    ]
   },
   {

--- a/spectral_connectivity/connectivity.py
+++ b/spectral_connectivity/connectivity.py
@@ -147,7 +147,7 @@ class Connectivity:
 
         # Validate expectation_type early
         if expectation_type not in EXPECTATION:
-            allowed_values = ', '.join(f"'{k}'" for k in sorted(EXPECTATION.keys()))
+            allowed_values = ", ".join(f"'{k}'" for k in sorted(EXPECTATION.keys()))
             raise ValueError(
                 f"Invalid expectation_type '{expectation_type}'. "
                 f"Allowed values are: {allowed_values}"

--- a/tests/test_expectation_validation.py
+++ b/tests/test_expectation_validation.py
@@ -10,19 +10,24 @@ def test_valid_expectation_types():
     n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals = (1, 2, 3, 5, 2)
     fourier_coefficients = (
         np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
-        + 1j * np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
+        + 1j
+        * np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
     ).astype(np.complex128)
 
     # All these should work without error
     valid_types = [
-        "time", "trials", "tapers",
-        "time_trials", "time_tapers", "trials_tapers", "time_trials_tapers"
+        "time",
+        "trials",
+        "tapers",
+        "time_trials",
+        "time_tapers",
+        "trials_tapers",
+        "time_trials_tapers",
     ]
 
     for expectation_type in valid_types:
         conn = Connectivity(
-            fourier_coefficients=fourier_coefficients,
-            expectation_type=expectation_type
+            fourier_coefficients=fourier_coefficients, expectation_type=expectation_type
         )
         assert conn.expectation_type == expectation_type
 
@@ -33,15 +38,15 @@ def test_invalid_expectation_type_raises_error():
     n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals = (1, 2, 3, 5, 2)
     fourier_coefficients = (
         np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
-        + 1j * np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
+        + 1j
+        * np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
     ).astype(np.complex128)
 
     invalid_type = "invalid_option"
 
     with pytest.raises(ValueError) as exc_info:
         Connectivity(
-            fourier_coefficients=fourier_coefficients,
-            expectation_type=invalid_type
+            fourier_coefficients=fourier_coefficients, expectation_type=invalid_type
         )
 
     error_msg = str(exc_info.value)
@@ -58,12 +63,13 @@ def test_case_sensitive_expectation_type():
     n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals = (1, 2, 3, 5, 2)
     fourier_coefficients = (
         np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
-        + 1j * np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
+        + 1j
+        * np.random.randn(n_time_samples, n_trials, n_tapers, n_fft_samples, n_signals)
     ).astype(np.complex128)
 
     # Should fail - case sensitivity
     with pytest.raises(ValueError):
         Connectivity(
             fourier_coefficients=fourier_coefficients,
-            expectation_type="TRIALS"  # uppercase should fail
+            expectation_type="TRIALS",  # uppercase should fail
         )


### PR DESCRIPTION
## Summary
- Add early validation of `expectation_type` parameter in `Connectivity.__init__`
- Provide clear error messages listing all allowed values when invalid input is given
- Improve user experience with actionable feedback

## Changes
- **connectivity.py:** Add validation against `EXPECTATION` dict keys with helpful error message
- **New test suite:** 3 tests covering valid types, invalid input, and case sensitivity

## User Experience Improvement
Before: Cryptic KeyError deep in call stack  
After: Clear ValueError at instantiation with allowed options

```python
# Example error message:
ValueError: Invalid expectation_type 'invalid_option'. 
Allowed values are: 'tapers', 'time', 'time_tapers', 'time_trials', 'time_trials_tapers', 'trials', 'trials_tapers'
```

## Test plan
- [x] All valid expectation types work correctly  
- [x] Invalid types raise ValueError with helpful message
- [x] Case sensitivity enforced
- [x] All existing tests maintain same status

🤖 Generated with [Claude Code](https://claude.ai/code)